### PR TITLE
Ver 2.0.3

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -1,7 +1,8 @@
 <?php get_header(); ?>
 
 <div class="content-wrapper">
-  <?php if (get_theme_mod('front_page_news_category') != null) { ?>
+  <?php $cat_id = get_theme_mod('front_page_news_category') != null ? get_theme_mod('front_page_news_category') : get_categories(array( 'fields' => 'ids'))[0]; ?>
+  <?php if ($cat_id != null) { ?>
     <div class="front-page-news-wrapper">
       <h1 class="front-page-title"><?php echo get_theme_mod('front_page_news_title') != null ? get_theme_mod('front_page_news_title') : 'Neuigkeiten'; ?></h1>
 
@@ -9,7 +10,7 @@
         <?php
         $news_posts = get_posts(array(
             'numberposts' => 8,
-            'category' => get_cat_ID(get_theme_mod('front_page_news_category')),
+            'category' => get_cat_ID($cat_id),
             'no_found_rows'  => true
         ));
 
@@ -38,7 +39,7 @@
           <?php } ?>
       </div>
 
-      <a href="<?php echo get_category_link(get_cat_ID(get_theme_mod('front_page_news_category'))) ?>" title="Alle Neuigkeiten" class="front-page-large-link">Alle Neuigkeiten &gt;</a>
+      <a href="<?php echo get_category_link(get_cat_ID($cat_id)) ?>" title="Alle Neuigkeiten" class="front-page-large-link">Alle Neuigkeiten &gt;</a>
     </div>
   <?php } ?>
 

--- a/functions.php
+++ b/functions.php
@@ -187,24 +187,68 @@
 
   /* Data protection page warning */
   function no_data_protection_page_warning() {
-    if (get_theme_mod('data_protection_page', '0') === '0') { ?>
-      <div class="notice-warning notice">
+    if (get_theme_mod('data_protection_page', '0') === '0' && !get_theme_mod('disable_data_protection_warning', false)) { ?>
+      <div class="notice-warning notice is-dismissible" id="lhgDataProtectionWarning">
+        <button
+          type="button"
+          class="notice-dismiss"
+          onclick="jQuery.post(ajaxurl, { 'action': 'disable_data_protection_warning' }, function(response) {
+    					jQuery('#lhgDataProtectionWarning').hide();
+    				});"
+          >
+          <span class="screen-reader-text">Diese Meldung ausblenden.</span>
+        </button>
+
         <p>Du hast derzeit keine Seite als Datenschutzerklärung festgelegt. Wir empfehlen dir <strong>dringend</strong>, dies in den Themeeinstellungen im <a href="<?php echo wp_customize_url(); ?>" title="Link zum Customizer">Customizer</a> zu tun.</p>
       </div>
     <?php }
   }
   add_action('admin_notices', 'no_data_protection_page_warning');
 
+  function disable_data_protection_warning() {
+    set_theme_mod('disable_data_protection_warning', true);
+  }
+  add_action('wp_ajax_disable_data_protection_warning', 'disable_data_protection_warning');
+  add_action('wp_ajax_nopriv_disable_data_protection_warning', 'disable_data_protection_warning');
+  function enable_data_protection_warning() {
+    if (get_theme_mod('data_protection_page', '0') !== '0') {
+      set_theme_mod('disable_data_protection_warning', false);
+    }
+  }
+  add_action('customize_save_after', 'enable_data_protection_warning');
+
 
   /* No logo set warning */
   function no_logo_set_warning() {
-    if (!has_custom_logo()) { ?>
-      <div class="notice-warning error">
+    if (!has_custom_logo() && !get_theme_mod('disable_missing_logo_warning', false)) { ?>
+      <div class="notice-warning error notice is-dismissible" id="lhgMissingLogoWarning">
+        <button
+          type="button"
+          class="notice-dismiss"
+          onclick="jQuery.post(ajaxurl, { 'action': 'disable_missing_logo_warning' }, function(response) {
+    					jQuery('#lhgMissingLogoWarning').hide();
+    				});"
+          >
+          <span class="screen-reader-text">Diese Meldung ausblenden.</span>
+        </button>
+
         <p>Du hast momentan kein Logo für eure Website festgelegt. Wir empfehlen dir dringend, das LHG-Logo deiner Gruppe im <a href="<?php echo wp_customize_url(); ?>" title="Link zum Customizer">Customizer</a> einzurichten. Alle Logos für LHGs findest du in der <a href="https://bundeslhg.sharepoint.com/:f:/s/LHG-Cloud/El8w8EVDNRVGnXinyaoHeXABCcRLo85d9WrdHgtlnWeYag?e=JVWK8Z" title="Link zur LHG-Cloud" target="_blank">LHG-Cloud</a>. Sollte deine Gruppe noch kein Logo haben, wende dich gerne an den Bundesvorstand.</p>
       </div>
     <?php }
   }
   add_action('admin_notices', 'no_logo_set_warning');
+
+  function disable_missing_logo_warning() {
+    set_theme_mod('disable_missing_logo_warning', true);
+  }
+  add_action('wp_ajax_disable_missing_logo_warning', 'disable_missing_logo_warning');
+  add_action('wp_ajax_nopriv_disable_missing_logo_warning', 'disable_missing_logo_warning');
+  function enable_missing_logo_warning() {
+    if (has_custom_logo()) {
+      set_theme_mod('disable_missing_logo_warning', false);
+    }
+  }
+  add_action('customize_save_after', 'enable_missing_logo_warning');
 
 
 ?>

--- a/header.php
+++ b/header.php
@@ -28,7 +28,14 @@
 
     <meta name="description" content="<?php echo is_front_page() ? bloginfo('description') : get_the_excerpt(get_the_ID()); ?>">
 
-    <title><?php bloginfo('name'); ?> | <?php is_front_page() ? bloginfo('description') : wp_title(''); ?></title>
+    <title>
+      <?php bloginfo('name'); ?>
+      <?php if (is_front_page()) {
+        echo get_bloginfo('description') != '' ? ' | ' . get_bloginfo('description') : '';
+      } else {
+        ?> | <?php wp_title('');
+      } ?>
+    </title>
     <link rel="profile" href="http://gmpg.org/xfn/11">
     <link rel="pingback" href="<?php bloginfo('pingback_url'); ?>">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.4/css/all.css">
@@ -165,6 +172,7 @@
                   'menu_class' => 'header-menu',
                   'container' => '',
                   'theme_location' => 'secondary',
+                  'depth' => 1
                 ));
               ?>
             </nav>

--- a/inc/help/help_settings.php
+++ b/inc/help/help_settings.php
@@ -116,6 +116,9 @@
   </li>
   <li>
     <h3>Kleines Zusatzmenü im Header und Footer</h3>
+		<div class="notice-warning notice">
+				<p>Dieses Menü wird im Header nicht immer sowie lediglich die oberste Ebene der Menühierarchie und maximal sieben Einträge angezeigt. Im Footer ist stets das volle Zusatzmenü zu sehen.</p>
+		</div>
 		<p>Zusätzlich kann ein kleines Zusatzmenü im Header und Footer angezeigt werden. Dieses Menü ist optional und wird im Header nicht immer angezeigt. Es eignet sich also nicht für Hauptseiten, sondern vorzugsweise für gelegentlich benötigte Unterseiten (z.B. das Impressum).</p>
 		<p>Unter "Weitere Themeeinstellungen" wird beschrieben, wie das Footer-Menü noch weiter angepasst werden kann.</p>
 	</li>

--- a/inc/post-types.php
+++ b/inc/post-types.php
@@ -115,7 +115,7 @@ function post_type_events() {
       'singular_name' => 'Veranstaltung',
       'menu_name' => 'Veranstaltungen',
       'parent_item_colon' => 'Übergeordnete Veranstaltung',
-      'all_items' => 'Alle Veranstaltungen',
+      'all_items' => 'Veranstaltungen',
       'view_item' => 'Veranstaltung anzeigen',
       'add_new_item' => 'Veranstaltung erstellen',
       'add_new' => 'Erstellen',
@@ -259,6 +259,7 @@ function register_taxonomy_calendar() {
      'labels'            => $labels,
      'show_ui'           => true,
      'show_admin_column' => true,
+     'show_in_nav_menus' => false,
      'query_var'         => true,
      'rewrite'           => ['slug' => 'calendar'],
    );
@@ -341,7 +342,7 @@ function post_type_resolutions() {
       'singular_name' => 'Beschluss',
       'menu_name' => 'Beschlüsse',
       'parent_item_colon' => 'Übergeordneter Beschluss',
-      'all_items' => 'Alle Beschlüsse',
+      'all_items' => 'Beschlüsse',
       'view_item' => 'Beschluss anzeigen',
       'add_new_item' => 'Beschluss erstellen',
       'add_new' => 'Erstellen',
@@ -381,6 +382,7 @@ function register_taxonomy_applicants() {
     'labels'            => $labels,
     'show_ui'           => true,
     'show_admin_column' => true,
+    'show_in_nav_menus' => false,
     'query_var'         => true,
     'rewrite'           => ['slug' => 'applicants'],
   );
@@ -405,6 +407,7 @@ function register_taxonomy_assembly() {
      'labels'            => $labels,
      'show_ui'           => true,
      'show_admin_column' => true,
+     'show_in_nav_menus' => false,
      'query_var'         => true,
      'rewrite'           => ['slug' => 'assembly'],
    );
@@ -429,6 +432,7 @@ function register_taxonomy_resolutiontags() {
      'labels'            => $labels,
      'show_ui'           => true,
      'show_admin_column' => true,
+     'show_in_nav_menus' => false,
      'query_var'         => true,
      'rewrite'           => ['slug' => 'resolutiontags'],
    );

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
   Theme Name: LHG-Theme 2022
   Author: Katharina Lauterbach & Maxi Wiegand
   Description: <strong>Das offizielle Theme für die Liberalen Hochschulgruppen.</strong> Jede Verwendung außerhalb der vorgesehenen Webseiten bedarf der vorherigen Einwilligung durch den Bundesverband Liberaler Hochschulgruppen sowie den Autoren. <em>Für Bugs oder Verbesserungen:</em> <a href="https://github.com/MxnWgd/lhg-theme/issues" title="Github">Github</a>.
-  Version: 2.0.2.1
+  Version: 2.0.3
 	Requires at least: 6.0
 	Tested up to: 6.0.3
   Text Domain: lhg
@@ -1095,6 +1095,11 @@ option {
 	left: 0;
 }
 
+.secondary-nav ul li:nth-child(n+8) {
+	display: none;
+}
+
+
 .header-navigation-button {
 	margin: 15px 20px 15px 0;
 	display: none;
@@ -1927,7 +1932,6 @@ option {
 	color: var(--dark-text-color);
 	background: #FFFFFF;
 }
-
 .dark-background .front-page-event-list .event-wrapper {
 	color: var(--bright-text-color);
 	background: var(--dark-background-color);
@@ -1936,7 +1940,6 @@ option {
 .front-page-event-list .event-wrapper-title {
 	color: var(--dark-accent-color);
 }
-
 .dark-background .front-page-event-list .event-wrapper-title {
 	color: var(--light-accent-color);
 }
@@ -1945,7 +1948,6 @@ option {
 	background-color: #FFFFFF;
 	color: var(--dark-text-color);
 }
-
 .dark-background .front-page-event-list .event-wrapper-date {
 	background-color: var(--dark-background-color);
 	color: var(--bright-text-color);
@@ -1955,7 +1957,6 @@ option {
 .front-page-event-list .event-wrapper-date-day {
 	color: var(--dark-accent-color);
 }
-
 .dark-background .front-page-event-list .event-wrapper-date-day {
 	color: var(--light-accent-color);
 }
@@ -1963,7 +1964,6 @@ option {
 .front-page-event-list .event-wrapper .post-meta {
 	color: var(--dark-text-color);
 }
-
 .dark-background .front-page-event-list .event-wrapper .post-meta {
 	color: var(--bright-text-color);
 }
@@ -1971,7 +1971,6 @@ option {
 .front-page-event-list .event-wrapper .post-meta a {
 	color: var(--dark-text-color);
 }
-
 .dark-background .front-page-event-list .event-wrapper .post-meta a {
 	color: var(--bright-text-color);
 }
@@ -1979,35 +1978,32 @@ option {
 .front-page-event-list .event-wrapper-description {
 	color: var(--dark-text-color);
 }
-
 .dark-background .front-page-event-list .event-wrapper-description {
 	color: var(--bright-text-color);
+}
+
+.front-page-event-list .event-wrapper-description a {
+	color: var(--dark-accent-color);
+	background-image: linear-gradient(var(--dark-accent-color) 0%, var(--dark-accent-color) 100%);
+}
+.front-page-event-list .event-wrapper-description a:hover,
+.front-page-event-list .event-wrapper-description a:focus {
+	color: var(--bright-text-color);
+}
+.dark-background .front-page-event-list .event-wrapper-description a {
+	color: var(--light-accent-color);
+	background-image: linear-gradient(var(--light-accent-color) 0%, var(--light-accent-color) 100%);
+}
+.dark-background .front-page-event-list .event-wrapper-description a:hover,
+.dark-background .front-page-event-list .event-wrapper-description a:focus {
+	color: var(--dark-text-color);
 }
 
 .front-page-event-list .event-wrapper-description .expand-icon-ud {
   border-color: var(--dark-text-color);
 }
-
 .dark-background .front-page-event-list .event-wrapper-description .expand-icon-ud {
   border-color: var(--bright-text-color);
-}
-
-.front-page-event-list .events-page-link {
-	color: var(--dark-accent-color);
-	background-image: linear-gradient(var(--dark-accent-color) 0%, var(--dark-accent-color) 100%);
-}
-.front-page-event-list .events-page-link:hover,
-.front-page-event-list .events-page-link:focus {
-	color: var(--bright-text-color);
-}
-
-.dark-background .front-page-event-list .events-page-link {
-	color: var(--light-accent-color);
-	background-image: linear-gradient(var(--light-accent-color) 0%, var(--light-accent-color) 100%);
-}
-.dark-background .front-page-event-list .events-page-link:hover,
-.dark-background .front-page-event-list .events-page-link:focus {
-	color: var(--dark-background-color);
 }
 
 
@@ -2136,6 +2132,15 @@ footer {
 .dark-background .footer-nav ul li a:focus {
 	color: var(--bright-text-color);
 	text-decoration: underline;
+}
+
+.footer-nav > ul > li > ul.sub-menu > li {
+	opacity: 0.7;
+	font-size: 0.9em;
+}
+
+.footer-nav li.menu-item-has-children {
+	padding-right: 0;
 }
 
 .footer-menu-button,


### PR DESCRIPTION
- added fallback to use first found category for front page news list if  none set (#130)
- added dismiss-option to missing-logo-warning and  data-protection-page-warning (#131)
- improved display of small menu in header (#132)
- improved title behavior for no subtitle #133
- improved default menu titles for events & resolutions (#138)
- removed taxonomies from menu options (#137)
- fixed links event tiles front page (#139)